### PR TITLE
Ported ERT to Python 3.x and gnuplot 6.0

### DIFF
--- a/Empirical_Roofline_Tool-1.1.0/Plot/graph1.gnu.template
+++ b/Empirical_Roofline_Tool-1.1.0/Plot/graph1.gnu.template
@@ -57,7 +57,7 @@ set samples 100, 100
 set isosamples 10, 10
 set surface
 unset contour
-set clabel '%8.3g'
+set cntrlabel format "%8.3g"
 set mapping cartesian
 set datafile separator whitespace
 unset hidden3d

--- a/Empirical_Roofline_Tool-1.1.0/Plot/graph2.gnu.template
+++ b/Empirical_Roofline_Tool-1.1.0/Plot/graph2.gnu.template
@@ -57,7 +57,7 @@ set samples 100, 100
 set isosamples 10, 10
 set surface
 unset contour
-set clabel '%8.3g'
+set cntrlabel format "%8.3g"
 set mapping cartesian
 set datafile separator whitespace
 unset hidden3d

--- a/Empirical_Roofline_Tool-1.1.0/Plot/graph3.gnu.template
+++ b/Empirical_Roofline_Tool-1.1.0/Plot/graph3.gnu.template
@@ -57,7 +57,7 @@ set samples 100, 100
 set isosamples 10, 10
 set surface
 unset contour
-set clabel '%8.3g'
+set cntrlabel format "%8.3g"
 set mapping cartesian
 set datafile separator whitespace
 unset hidden3d

--- a/Empirical_Roofline_Tool-1.1.0/Plot/graph4.gnu.template
+++ b/Empirical_Roofline_Tool-1.1.0/Plot/graph4.gnu.template
@@ -57,7 +57,7 @@ set samples 100, 100
 set isosamples 10, 10
 set surface
 unset contour
-set clabel '%8.3g'
+set cntrlabel format "%8.3g"
 set mapping cartesian
 set datafile separator whitespace
 unset hidden3d

--- a/Empirical_Roofline_Tool-1.1.0/Plot/roofline.gnu.template
+++ b/Empirical_Roofline_Tool-1.1.0/Plot/roofline.gnu.template
@@ -57,7 +57,7 @@ set samples 1000, 1000
 set isosamples 10, 10
 set surface
 unset contour
-set clabel '%8.3g'
+set cntrlabel format "%8.3g"
 set mapping cartesian
 set datafile separator whitespace
 unset hidden3d

--- a/Empirical_Roofline_Tool-1.1.0/Python/ert_core.py
+++ b/Empirical_Roofline_Tool-1.1.0/Python/ert_core.py
@@ -1,7 +1,8 @@
 import sys,operator,subprocess,os,glob,filecmp,math
 import socket,platform,time,json,optparse,ast
 
-from ert_utils import *
+from .ert_utils import *
+from functools import reduce
 
 def text_list_2_string(text_list):
   return reduce(operator.add,[t+" " for t in text_list])
@@ -97,8 +98,8 @@ class ert_core:
 
   def configure(self):
     if self.options.verbose > 0:
-      print
-      print "Reading configuration from '%s'..." % self.configure_filename
+      print()
+      print("Reading configuration from '%s'..." % self.configure_filename)
 
     try:
       configure_file = open(self.configure_filename,"r")
@@ -134,9 +135,9 @@ class ert_core:
 
     if self.options.verbose > 0:
       if made_results:
-        print "  Making new results directory, %s..." % self.results_dir
+        print("  Making new results directory, %s..." % self.results_dir)
       else:
-        print "  Using existing results directory, %s..." % self.results_dir
+        print("  Using existing results directory, %s..." % self.results_dir)
 
     run_files = glob.glob("%s/Run.[0-9][0-9][0-9]" % self.results_dir)
     used_run_files = []
@@ -149,7 +150,7 @@ class ert_core:
           self.results_dir = run_file
           no_dir = False
           if self.options.verbose > 0:
-            print "    Using existing run directory, %s..." % self.results_dir
+            print("    Using existing run directory, %s..." % self.results_dir)
           break
         else:
           used_run_files.append(run_file)
@@ -162,24 +163,24 @@ class ert_core:
       if self.options.build or self.options.run:
         if len(used_run_list) == 0:
           used_run_list = [0]
-        for n in xrange(1,max(used_run_list)+2):
+        for n in range(1,max(used_run_list)+2):
           if n not in used_run_list:
             self.results_dir = "%s/Run.%03d" % (self.results_dir,n)
             if self.options.verbose > 0:
               if made_results:
-                print "    Making new run directory, '%s'..." % self.results_dir
+                print("    Making new run directory, '%s'..." % self.results_dir)
               else:
-                print
-                print "*** WARNING ***"
-                print "**"
-                print "**  Making new run directory, '%s'," % self.results_dir
-                print "**    because the current connfiguration file, '%s' " % self.configure_filename
-                print "**    doesn't match the configuration files, 'config.ert', under:"
-                print "**"
+                print()
+                print("*** WARNING ***")
+                print("**")
+                print("**  Making new run directory, '%s'," % self.results_dir)
+                print("**    because the current connfiguration file, '%s' " % self.configure_filename)
+                print("**    doesn't match the configuration files, 'config.ert', under:")
+                print("**")
                 for u in sorted(used_run_files):
-                  print "**      %s" % u
-                print "**"
-                print "*** WARNING ***"
+                  print("**      %s" % u)
+                print("**")
+                print("*** WARNING ***")
 
             command = ["mkdir",self.results_dir]
             if execute_noshell(command,self.options.verbose > 1) != 0:
@@ -197,7 +198,7 @@ class ert_core:
         return 1
 
     if self.options.verbose > 0:
-      print
+      print()
 
     return 0
 
@@ -205,8 +206,8 @@ class ert_core:
     if self.options.build:
       if self.options.verbose > 0:
         if self.options.verbose > 1:
-          print
-        print "  Building ERT core code..."
+          print()
+        print("  Building ERT core code...")
 
       command_prefix =                                                       \
         self.dict["CONFIG"]["ERT_CC"]                                                + \
@@ -230,7 +231,7 @@ class ert_core:
       command = command_prefix + \
                 ["-c","%s/Drivers/%s.c" % (self.exe_path,self.dict["CONFIG"]["ERT_DRIVER"][0])] + \
                 ["-o","%s/%s.o" % (self.flop_dir,self.dict["CONFIG"]["ERT_DRIVER"][0])]
-      print("Failed command", command)
+      print(("Failed command", command))
       if execute_noshell(command,self.options.verbose > 1) != 0:
         sys.stderr.write("Compiling driver, %s, failed\n" % self.dict["CONFIG"]["ERT_DRIVER"][0])
         return 1
@@ -271,10 +272,10 @@ class ert_core:
       sys.stderr.write("Unable to open output file, %s, to add metadata\n" % outputfile)
       return 1
 
-    for k,v in self.metadata.items():
+    for k,v in list(self.metadata.items()):
       output.write("%s  %s\n" % (k,v))
 
-    for k,v in self.dict.items():
+    for k,v in list(self.dict.items()):
       output.write("%s  %s\n" % (k,v))
 
     output.close()
@@ -285,8 +286,8 @@ class ert_core:
     if self.options.run:
       if self.options.verbose > 0:
         if self.options.verbose > 1:
-          print
-        print "  Running ERT core code..."
+          print()
+        print("  Running ERT core code...")
 
     self.run_list = []
 
@@ -384,10 +385,10 @@ class ert_core:
                 if self.options.run:
                   if os.path.exists("%s/run.done" % run_dir):
                     if self.options.verbose > 1:
-                      print "    Skipping %s - already run" % print_str
+                      print("    Skipping %s - already run" % print_str)
                   else:
                     if self.options.verbose > 0:
-                      print "    %s" % print_str
+                      print("    %s" % print_str)
 
                     command = base_command
 
@@ -401,7 +402,7 @@ class ert_core:
 
                     command = "(" + command + ") > %s/try.ERT_TRY_NUM 2>&1 " % run_dir
 
-                    for t in xrange(1,num_experiments+1):
+                    for t in range(1,num_experiments+1):
                       output = "%s/try.%03d" % (run_dir,t) 
 
                       cur_command = command
@@ -422,18 +423,18 @@ class ert_core:
                       return 1
 
                   if self.options.verbose > 1:
-                    print
+                    print()
 
     return 0
 
   def process(self):
     if self.options.post:
       if self.options.verbose > 0:
-        print "  Processing results..."
+        print("  Processing results...")
 
       for run in self.run_list:
         if self.options.verbose > 1:
-          print "   ",run
+          print("   ",run)
 
         command = ["cat %s/try.* | %s/Scripts/preprocess.py > %s/pre" % (run,self.exe_path,run)]
         if execute_shell(command,self.options.verbose > 1) != 0:
@@ -451,7 +452,7 @@ class ert_core:
           return 1
 
         if self.options.verbose > 1:
-          print
+          print()
 
     return 0
 
@@ -494,7 +495,7 @@ class ert_core:
           return 1
 
         if self.options.verbose > 1:
-          print
+          print()
 
     return 0
 
@@ -562,14 +563,14 @@ class ert_core:
     emp_gbytes_metadata = {}
     emp_gbytes_data = []
 
-    for i in xrange(0,len(gbyte)):
+    for i in range(0,len(gbyte)):
       if gbyte[i] == "META_DATA":
         break
       else:
         gbyte_split = gbyte[i].split()
         emp_gbytes_data.append([gbyte_split[1],float(gbyte_split[0])])
 
-    for j in xrange(i+1,len(gbyte)):
+    for j in range(i+1,len(gbyte)):
       metadata = gbyte[j]
 
       parts = metadata.partition(" ")
@@ -635,7 +636,7 @@ class ert_core:
   def roofline(self):
     if self.options.post:
       if self.options.verbose > 0:
-        print "Gathering the final roofline results..."
+        print("Gathering the final roofline results...")
 
       depth_string = "/*"
       if self.dict["CONFIG"]["ERT_MPI"][0] == "True":
@@ -650,10 +651,9 @@ class ert_core:
       if result[0] != 0:
         sys.stderr.write("Unable to create final roofline results\n")
         return 1
+      lines = (result[1].decode()).split("\n")
 
-      lines = result[1].split("\n")
-
-      for i in xrange(0,len(lines)):
+      for i in range(0,len(lines)):
         if len(lines[i]) == 0:
           break
 
@@ -676,19 +676,19 @@ class ert_core:
       line = gflop_lines[0].split()
       gflops_emp = [float(line[0]),line[1]]
 
-      for i in xrange(0,len(gbyte_lines)):
+      for i in range(0,len(gbyte_lines)):
         if gbyte_lines[i] == "META_DATA":
           break
 
       num_mem = i
       gbytes_emp = num_mem * [0]
 
-      for i in xrange(0,num_mem):
+      for i in range(0,num_mem):
         line = gbyte_lines[i].split()
         gbytes_emp[i] = [float(line[0]),line[1]]
 
       x = num_mem * [0.0]
-      for i in xrange(0,len(gbytes_emp)):
+      for i in range(0,len(gbytes_emp)):
         x[i] = gflops_emp[0]/gbytes_emp[i][0]
 
       if self.options.gnuplot:
@@ -739,7 +739,7 @@ class ert_core:
         alpha = 1.065
 
         label_over = True
-        for i in xrange(0,len(gbytes_emp)):
+        for i in range(0,len(gbytes_emp)):
           if i > 0:
             if label_over and gbytes_emp[i-1][0] / gbytes_emp[i][0] < 1.5:
               label_over = False
@@ -766,7 +766,7 @@ class ert_core:
 
         plotfile.write("plot \\\n")
 
-        for i in xrange(0,len(gbytes_emp)):
+        for i in range(0,len(gbytes_emp)):
           plotfile.write("     (x <= %.7le ? %.7le * x : 1/0) lc 1 lw 2,\\\n" % (x[i],gbytes_emp[i][0]))
 
         plotfile.write("     (x >= %.7le ? %.7le : 1/0) lc 3 lw 2\n" % (x[0],gflops_emp[0]))
@@ -779,12 +779,12 @@ class ert_core:
           return 1
 
       if self.options.verbose > 0:
-        print
-        print "+-------------------------------------------------"
+        print()
+        print("+-------------------------------------------------")
         if self.options.gnuplot:
-          print "| Empirical roofline graph:    '%s/roofline.ps'"   % self.results_dir
-        print "| Empirical roofline database: '%s/roofline.json'" % self.results_dir
-        print "+-------------------------------------------------"
-        print
+          print("| Empirical roofline graph:    '%s/roofline.ps'"   % self.results_dir)
+        print("| Empirical roofline database: '%s/roofline.json'" % self.results_dir)
+        print("+-------------------------------------------------")
+        print()
 
     return 0

--- a/Empirical_Roofline_Tool-1.1.0/Python/ert_utils.py
+++ b/Empirical_Roofline_Tool-1.1.0/Python/ert_utils.py
@@ -1,4 +1,5 @@
 import operator,subprocess,sys,os.path
+from functools import reduce
 
 # Make a list into a space seperated string
 def list_2_string(text_list):
@@ -7,7 +8,7 @@ def list_2_string(text_list):
 # Execute a command without generating a new shell
 def execute_noshell(command,echo=True):
   if echo:
-    print "   ",list_2_string(command)
+    print("   ",list_2_string(command))
     sys.stdout.flush()
 
   if subprocess.call(command,shell=False) != 0:
@@ -19,9 +20,9 @@ def execute_noshell(command,echo=True):
 def execute_shell(command,echo=True):
   if echo:
     if isinstance(command,list):
-      print "   ",command[0]
+      print("   ",command[0])
     else:
-      print "   ",command
+      print("   ",command)
     sys.stdout.flush()
 
   if subprocess.call(command,shell=True) != 0:
@@ -33,7 +34,7 @@ def execute_shell(command,echo=True):
 # and return any output from "stdout"
 def stdout_noshell(command,echo=True):
   if echo:
-    print "   ",list_2_string(command)
+    print("   ",list_2_string(command))
     sys.stdout.flush()
 
   p = subprocess.Popen(command,shell=False,stdout=subprocess.PIPE)
@@ -49,9 +50,9 @@ def stdout_noshell(command,echo=True):
 def stdout_shell(command,echo=True):
   if echo:
     if isinstance(command,list):
-      print "   ",command[0]
+      print("   ",command[0])
     else:
-      print "   ",command
+      print("   ",command)
     sys.stdout.flush()
 
   p = subprocess.Popen(command,shell=True,stdout=subprocess.PIPE)
@@ -80,7 +81,7 @@ def parse_int_list(input):
     if len(minmax) == 1:
       retlist.append(int(minmax[0]))
     else:
-      for i in xrange(int(minmax[0]),int(minmax[1])+1):
+      for i in range(int(minmax[0]),int(minmax[1])+1):
         retlist.append(i)
 
   return sorted(list(set(retlist)))

--- a/Empirical_Roofline_Tool-1.1.0/Scripts/maximum.py
+++ b/Empirical_Roofline_Tool-1.1.0/Scripts/maximum.py
@@ -13,16 +13,16 @@ for l in os.sys.stdin:
   if len(m) > 0 and m[0] == "META_DATA":
     found_metadata = True
 
-    print lastLine,
-    print
+    print(lastLine, end=' ')
+    print()
 
   if found_metadata:
-    print l,
+    print(l, end=' ')
   else:
     if len(m) == 11 and m[0][0] != "#":
       if m[0] != field0:
         if lastLine != "":
-          print lastLine,
+          print(lastLine, end=' ')
         field0 = m[0]
       lastLine = l
 

--- a/Empirical_Roofline_Tool-1.1.0/Scripts/preprocess.py
+++ b/Empirical_Roofline_Tool-1.1.0/Scripts/preprocess.py
@@ -43,11 +43,11 @@ for l in os.sys.stdin:
   if not is_metadata and len(m) == INPUT.size:
     try:
       wkey = int(m[INPUT.wkey])
-      if not data.has_key(wkey):
+      if wkey not in data:
         data[wkey] = dict()
 
       tkey = int(m[INPUT.tkey])
-      if not data[wkey].has_key(tkey):
+      if tkey not in data[wkey]:
         data[wkey][tkey] = STATS.size*[0]
         first = True
       else:
@@ -76,15 +76,15 @@ for l in os.sys.stdin:
     except ValueError:
       pass
 
-for wkey in sorted(data.iterkeys()):
+for wkey in sorted(data.keys()):
   tdict = data[wkey]
-  for tkey in sorted(tdict.iterkeys()):
+  for tkey in sorted(tdict.keys()):
     stats = tdict[tkey]
 
     msec_min = stats[STATS.msec_min]
 
     msec_med = sorted(stats[STATS.msec_med])
-    msec_med = msec_med[len(msec_med)/2]
+    msec_med = msec_med[len(msec_med)//2]
 
     msec_max = stats[STATS.msec_max]
 
@@ -100,7 +100,7 @@ for wkey in sorted(data.iterkeys()):
       GFLOP_sec_med = gflops/(msec_med/MEGA)
       GFLOP_sec_max = gflops/(msec_min/MEGA)
 
-      print wkey,          \
+      print(wkey,          \
             tkey,          \
             msec_min,      \
             msec_med,      \
@@ -110,11 +110,11 @@ for wkey in sorted(data.iterkeys()):
             GB_sec_max,    \
             GFLOP_sec_min, \
             GFLOP_sec_med, \
-            GFLOP_sec_max
+            GFLOP_sec_max)
 
-  print ""
+  print("")
 
-print "META_DATA"
-for k,m in metadata.items():
+print("META_DATA")
+for k,m in list(metadata.items()):
   if k != "META_DATA":
-    print k
+    print(k)

--- a/Empirical_Roofline_Tool-1.1.0/Scripts/roofline.py
+++ b/Empirical_Roofline_Tool-1.1.0/Scripts/roofline.py
@@ -72,15 +72,15 @@ for line in sys.stdin:
       elif save_band:
         max_band.append(line[:-1])
 
-print "  %7.2f %s EMP" % (max_gflops_value,max_gflops_name)
+print("  %7.2f %s EMP" % (max_gflops_value,max_gflops_name))
 
 for m in flop_metadata:
-  print m
+  print(m)
 
-print
+print()
 
 for b in max_band:
-  print "%s EMP" % b
+  print("%s EMP" % b)
 
 for m in band_metadata:
-  print m
+  print(m)

--- a/Empirical_Roofline_Tool-1.1.0/Scripts/summary.py
+++ b/Empirical_Roofline_Tool-1.1.0/Scripts/summary.py
@@ -8,7 +8,7 @@ def smooth(x,y):
 
   d = 0
 
-  for i in xrange(0,len(ys)):
+  for i in range(0,len(ys)):
     num = min(len(ys),i+d+1) - max(0,i-d)
     total = sum(ys[max(0,i-d):min(len(ys),i+d+1)])
     ys[i] = total/float(num)
@@ -17,7 +17,7 @@ def smooth(x,y):
 
 lines = os.sys.stdin.readlines()
 
-for i in xrange(0,len(lines)):
+for i in range(0,len(lines)):
   if lines[i] == "META_DATA\n":
     break
 
@@ -29,7 +29,7 @@ band   = [float(line.split()[6]) for line in lines]
 gflops = [float(line.split()[9]) for line in lines]
 
 weight = 0.0
-for i in xrange(0,len(x)-1):
+for i in range(0,len(x)-1):
   x1 = math.log(x[i])
   y1 = band[i]
 
@@ -59,7 +59,7 @@ totals = samples*[0.0]
 
 x,band = smooth(x,band)
 
-for i in xrange(0,samples):
+for i in range(0,samples):
   cband = i*dband
 
   for v in band:
@@ -67,14 +67,14 @@ for i in xrange(0,samples):
       totals[i] += v
       counts[i] += 1
 
-print "  %7.2f GFLOPs" % maxgflops
-print
+print("  %7.2f GFLOPs" % maxgflops)
+print()
 
 band_list = [[1000*maxband,1000]]
 
 maxc = -1
 maxi = -1
-for i in xrange(samples-3,1,-1):
+for i in range(samples-3,1,-1):
   if counts[i] > 6:
     if counts[i] > maxc:
       maxc = counts[i]
@@ -90,19 +90,19 @@ for i in xrange(samples-3,1,-1):
     maxc = -1
     maxi = -1
 
-print "  %7.2f Weight" % weight
-print
+print("  %7.2f Weight" % weight)
+print()
 
 band_name_list = ["DRAM"]
 cache_num = len(band_list)-1
 
-for cache in xrange(1,cache_num+1):
+for cache in range(1,cache_num+1):
   band_name_list = ["L%d" % (cache_num+1 - cache)] + band_name_list
 
 
 for (band,band_name) in zip(band_list,band_name_list):
-  print "  %7.2f %s" % (float(band[0])/band[1],band_name)
+  print("  %7.2f %s" % (float(band[0])/band[1],band_name))
 
-print
+print()
 for m in meta_lines:
-  print m,
+  print(m, end=' ')

--- a/Empirical_Roofline_Tool-1.1.0/ert
+++ b/Empirical_Roofline_Tool-1.1.0/ert
@@ -37,7 +37,7 @@ flops_list = parse_int_list(ert.dict["CONFIG"]["ERT_FLOPS"][0])
 for flop in flops_list:
   # A bit of output if any verbosity has been requested
   if ert.options.verbose > 0:
-    print "FLOP count %d..." % flop
+    print("FLOP count %d..." % flop)
     sys.stdout.flush()
 
   # Set the ERT object flops/element
@@ -73,7 +73,7 @@ for flop in flops_list:
   sys.stdout.flush()
 
   if ert.options.verbose > 0:
-    print
+    print()
 
 # When all the experiments have been processed, generate the roofline graph
 # and JSON output


### PR DESCRIPTION
1. Applied `2to3` changes to Python scripts
2. Replaced deprecated `gnuplot` flags with new versions

Tested on an AMD CPU with default driver and kernels, and the tool runs to completion. The output logs are copied below.

```
Reading configuration from 'Config/config.tharindu.linuxbox'...
  Making new results directory, Result.tharindu.linuxbox...
    Making new run directory, 'Result.tharindu.linuxbox/Run.001'...

FLOP count 1...
  Building ERT core code...
('Failed command', ['gcc', '-O3', '-msse3', '-mavx2', '-I./Kernels', '-DERT_FLOP=1', '-DERT_ALIGN=32', '-DERT_MEMORY_MAX=1073741824', '-DERT_WORKING_SET_MIN=1', '-DERT_TRIALS_MIN=1', '-DERT_OPENMP', '-openmp', '-c', './Drivers/driver1.c', '-o', 'Result.tharindu.linuxbox/Run.001/FLOPS.001/driver1.o'])
  Running ERT core code...
    OpenMP 1
    OpenMP 2
    OpenMP 4
    OpenMP 8
    OpenMP 16
  Processing results...

FLOP count 2...
  Building ERT core code...
('Failed command', ['gcc', '-O3', '-msse3', '-mavx2', '-I./Kernels', '-DERT_FLOP=2', '-DERT_ALIGN=32', '-DERT_MEMORY_MAX=1073741824', '-DERT_WORKING_SET_MIN=1', '-DERT_TRIALS_MIN=1', '-DERT_OPENMP', '-openmp', '-c', './Drivers/driver1.c', '-o', 'Result.tharindu.linuxbox/Run.001/FLOPS.002/driver1.o'])
  Running ERT core code...
    OpenMP 1
    OpenMP 2
    OpenMP 4
    OpenMP 8
    OpenMP 16
  Processing results...

FLOP count 4...
  Building ERT core code...
('Failed command', ['gcc', '-O3', '-msse3', '-mavx2', '-I./Kernels', '-DERT_FLOP=4', '-DERT_ALIGN=32', '-DERT_MEMORY_MAX=1073741824', '-DERT_WORKING_SET_MIN=1', '-DERT_TRIALS_MIN=1', '-DERT_OPENMP', '-openmp', '-c', './Drivers/driver1.c', '-o', 'Result.tharindu.linuxbox/Run.001/FLOPS.004/driver1.o'])
  Running ERT core code...
    OpenMP 1
    OpenMP 2
    OpenMP 4
    OpenMP 8
    OpenMP 16
  Processing results...

FLOP count 8...
  Building ERT core code...
('Failed command', ['gcc', '-O3', '-msse3', '-mavx2', '-I./Kernels', '-DERT_FLOP=8', '-DERT_ALIGN=32', '-DERT_MEMORY_MAX=1073741824', '-DERT_WORKING_SET_MIN=1', '-DERT_TRIALS_MIN=1', '-DERT_OPENMP', '-openmp', '-c', './Drivers/driver1.c', '-o', 'Result.tharindu.linuxbox/Run.001/FLOPS.008/driver1.o'])
  Running ERT core code...
    OpenMP 1
    OpenMP 2
    OpenMP 4
    OpenMP 8
    OpenMP 16
  Processing results...

FLOP count 16...
  Building ERT core code...
('Failed command', ['gcc', '-O3', '-msse3', '-mavx2', '-I./Kernels', '-DERT_FLOP=16', '-DERT_ALIGN=32', '-DERT_MEMORY_MAX=1073741824', '-DERT_WORKING_SET_MIN=1', '-DERT_TRIALS_MIN=1', '-DERT_OPENMP', '-openmp', '-c', '``./Drivers/driver1.c', '-o', 'Result.tharindu.linuxbox/Run.001/FLOPS.016/driver1.o'])
  Running ERT core code...
    OpenMP 1
    OpenMP 2
    OpenMP 4
    OpenMP 8
    OpenMP 16
  Processing results...

Gathering the final roofline results...

+-------------------------------------------------
| Empirical roofline graph:    'Result.tharindu.linuxbox/Run.001/roofline.ps'
| Empirical roofline database: 'Result.tharindu.linuxbox/Run.001/roofline.json'
+-------------------------------------------------

```